### PR TITLE
docs: typo, dead link, and missing file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A template notebook is provided as `asl_recognizer.ipynb`. The notebook is a com
 
 ### Run
 
-In a terminal or command window, navigate to the top-level project directory `asl_recognizer/` (that contains this README) and run one of the following command:
+In a terminal or command window, navigate to the top-level project directory `AIND_recognizer/` (that contains this README) and run one of the following command:
 
 `jupyter notebook asl_recognizer.ipynb`
 


### PR DESCRIPTION
README.md:
dead link: https://github.com/udacity/AIND-Recognizer/blob/master/boston104.handpositions.rybach-forster-dreuw-2009-09-25.full.xml (line 38)
missing file: speakerstats.csv (line 57)